### PR TITLE
Add the panel background color as a customizable option in theme.conf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+# C++ objects and libs
+*.slo
+*.lo
+*.o
+*.a
+*.la
+*.lai
+*.so
+*.dll
+*.dylib
+
+# Qt-es
+object_script.*.Release
+object_script.*.Debug
+*_plugin_import.cpp
+/.qmake.cache
+/.qmake.stash
+*.pro.user
+*.pro.user.*
+*.qbs.user
+*.qbs.user.*
+*.moc
+moc_*.cpp
+moc_*.h
+qrc_*.cpp
+ui_*.h
+*.qmlc
+*.jsc
+Makefile*
+*build-*
+
+# Qt unit tests
+target_wrapper.*
+
+# QtCreator
+*.autosave
+
+# QtCreator Qml
+*.qmlproject.user
+*.qmlproject.user.*
+
+# QtCreator CMake
+CMakeLists.txt.user*
+
+# QtCreator 4.8< compilation database 
+compile_commands.json
+
+# QtCreator local machine specific files for imported projects
+*creator.user*

--- a/Main.qml
+++ b/Main.qml
@@ -36,7 +36,7 @@ Pane{
     palette.highlight: config.ThemeColor
     palette.text: config.ThemeColor
     palette.buttonText: config.ThemeColor
-    palette.window: "#444444"
+    palette.window: config.PanelColor
 
     font.family: config.Font
     font.pointSize: config.FontSize !== "" ? config.FontSize : parseInt(height / 80)

--- a/theme.conf
+++ b/theme.conf
@@ -8,6 +8,7 @@ ScreenHeight=900
 ; Adjust to your resolution to help SDDM speed up on calculations
 
 # [Design Customizations]
+PanelColor="#444444"
 ThemeColor="navajowhite"
 AccentColor="sandybrown"
 ; Colors can be HEX or named (e.g. red/blue/blanchedalmond). See http://doc.qt.io/qt-5/qml-color.html#svg-color-reference


### PR DESCRIPTION
I tweaked the theme to my liking but found that the panel background was too similar to the theme
colors I chose which made everything was unreadable. I liked the colors I had picked so I figured I'd change the panel background. Now this option is exposed to users. I left the color in `theme.conf` as the original `#444444` instead of an SVG color name because 1.) none of the SVG grays were quite as dark and 2.) it shows users an example of a hex color entry.

I also added the [community standard Qt .gitignore file](https://github.com/github/gitignore/blob/master/Qt.gitignore). When testing this theme with `sddm-greeter --test-mode --theme <Path to theme>`, .qmlc files were generated and showed up in git. These need not be tracked as they are just compiled forms of the .qml files. 

Attached are the colors I had tried to use initially as well as the colors with a custom, darker background:

![default_background](https://user-images.githubusercontent.com/8602791/52915256-986d4e80-329f-11e9-8f6a-7e84402ce431.png)

![custom_background](https://user-images.githubusercontent.com/8602791/52915259-9f945c80-329f-11e9-8fb8-b2deb4dc8ac9.png)
