### PR TITLE
Configurable screen split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+theme.conf.user
+*~
+*.bak

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 2019-07-04
 ----------
-- Added InterfaceWidthDivider config item to easily control width of the input area
+- Added InterfaceWidthDivider config item to easily control width of the input area (@MarcinOrlowski)
 
 2019-06-14
 ----------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+2019-07-04
+----------
+- Added InterfaceWidthDivider config item to easily control width of the input area
+
 2019-06-14
 ----------
 - Added Hibernation support (@MarcinOrlowski)

--- a/Components/Clock.qml
+++ b/Components/Clock.qml
@@ -1,7 +1,7 @@
 //
 // This file is part of Sugar Dark, a theme for the Simple Display Desktop Manager.
 //
-// Copyright 2018 Marian Arlt
+// Copyright 2018-2019 Marian Arlt
 //
 // Sugar Dark is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Components/Input.qml
+++ b/Components/Input.qml
@@ -1,7 +1,7 @@
 //
 // This file is part of Sugar Dark, a theme for the Simple Display Desktop Manager.
 //
-// Copyright 2018 Marian Arlt
+// Copyright 2018-2019 Marian Arlt
 //
 // Sugar Dark is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Components/LoginForm.qml
+++ b/Components/LoginForm.qml
@@ -1,7 +1,7 @@
 //
 // This file is part of Sugar Dark, a theme for the Simple Display Desktop Manager.
 //
-// Copyright 2018 Marian Arlt
+// Copyright 2018-2019 Marian Arlt
 //
 // Sugar Dark is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Components/SessionButton.qml
+++ b/Components/SessionButton.qml
@@ -1,7 +1,7 @@
 //
 // This file is part of Sugar Dark, a theme for the Simple Display Desktop Manager.
 //
-// Copyright 2018 Marian Arlt
+// Copyright 2018-2019 Marian Arlt
 //
 // Sugar Dark is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Components/SystemButtons.qml
+++ b/Components/SystemButtons.qml
@@ -1,7 +1,7 @@
 //
 // This file is part of Sugar Dark, a theme for the Simple Display Desktop Manager.
 //
-// Copyright 2018 Marian Arlt
+// Copyright 2018-2019 Marian Arlt
 //
 // Sugar Dark is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by

--- a/Main.qml
+++ b/Main.qml
@@ -48,7 +48,7 @@ Pane{
 
         LoginForm {
             Layout.minimumHeight: parent.height
-            Layout.maximumWidth: parent.width / 2.5
+            Layout.maximumWidth: parent.width / config.InterfaceWidthDivider
         }
 
         Item {

--- a/README.md
+++ b/README.md
@@ -40,8 +40,10 @@ In the `[Theme]` section simply add the themes name: `Current=sugar-dark`. Also 
 
 ### Theming the theme
 
-Sugar is extremely customizable by editing its included `theme.conf` file. You can change the colors and images used, the time and date formats, the appearance of the whole interface and even how it works.  
+Sugar is extremely customizable by either (not recommended) editing its defaults in included `theme.conf` file or by creating `threme.conf.user` in the same directory with all the custom settings in it. The latter approach would prevent your settings from being overwritten by theme updates. You can change the colors and images used, the time and date formats, the appearance of the whole interface and even how it works.  
 And as if that wouldn't still be enough you can translate every single button and label because SDDM is still lacking behind with localization and clearly [needs your help](https://github.com/sddm/sddm/wiki/Localization)!
+
+To test your changes invoke `sddm-greeter --test-mode --theme <PATH-TO-THEME>`.
 
 Please read the [Sugar Wiki on Github](https://github.com/MarianArlt/sddm-sugar-light/wiki/Before-you-begin) for a detailed description of every variable available, what it does and the values it accepts. The `theme.conf` itself is also very well commented for you to get right at it.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Please read the [Sugar Wiki on Github](https://github.com/MarianArlt/sddm-sugar-
 
 ### Legal Notice
 
-Copyright (C) 2018 Marian Arlt.  
+Copyright (C) 2018-2019 Marian Arlt.  
 
 Sugar Dark is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.  
 

--- a/theme.conf
+++ b/theme.conf
@@ -1,3 +1,6 @@
+; DO NOT EDIT
+; To override dafaults create theme.conf.user file and put your values (and sections) there.
+
 [General]
 Background="Background.jpg"
 ; Must match the name of the image in the theme directory. Any standard image file format is allowed with transparency supported. (e.g. background.jpeg/illustration.GIF/Foto.png)
@@ -37,6 +40,10 @@ ForcePasswordFocus=true
 ; Give automatic focus to the password field. Together with ForceLastUser this makes for the fastest login experience. 
 ForceHideCompletePassword=false
 ; If you don't like to see any character at all not even while being entered set this to true.
+
+; Used to calculate how much of the screen width should be used by area with user interface (remaining space will be then used for the image).
+; Default value is 2.5, but for ultrawide screens you may want to set it i.e. to 4 or 5 to have 1/4th or 1/5th of you screen used by inputs only.
+InterfaceWidthDivider=2.5
 
 # [Translations]
 ; SDDM may lack proper translation for every element. The keys beginning with Translate... default to SDDM translations. Please help translate SDDM as much as possible for your language: https://github.com/sddm/sddm/wiki/Localization. These are in order as they appear on screen.


### PR DESCRIPTION
Added `InterfaceWidthDivider` config option to make Sugar more ultrawide monitor friendly as default divider  is not really working nicely on such config as demonstrated below: top portion, default 2.5 divider, below 5. 

![uw](https://user-images.githubusercontent.com/8041294/60662705-6b3fc800-9e5d-11e9-9fe8-1b584aca9fd6.png)
