### PR TITLE
Add defaultdisplay to avoid extra text in combobox

### DIFF
--- a/Components/Input.qml
+++ b/Components/Input.qml
@@ -49,6 +49,7 @@ Column {
             model: userModel
             currentIndex: model.lastIndex
             textRole: "name"
+            displayText: ""
             hoverEnabled: true
             onActivated: {
                 username.text = currentText


### PR DESCRIPTION
When user name starts with "w" it could be visible in combobox
![image](https://user-images.githubusercontent.com/3696319/71548551-8163b680-29b0-11ea-90e0-5e96ef5ff349.png)

I noticed it could be hidden by setting displayText to empty