### PR TITLE
Fix typos in config options

### DIFF
--- a/theme.conf
+++ b/theme.conf
@@ -72,8 +72,8 @@ ForceHideVirtualKeyboardButton="false"
 HeaderText=Welcome!
 ## Header can be empty to not display any greeting at all. Keep it short.
 
-TranslatePlaceholderUsername=""
-TranslatePlaceholderPassword=""
+TranslateUsernamePlaceholder=""
+TranslatePasswordPlaceholder=""
 TranslateShowPassword=""
 TranslateLogin=""
 TranslateLoginFailedWarning=""


### PR DESCRIPTION
In Input.qml, options TranslateUsernamePlaceholder and
TranslatePasswordPlaceholder are used for user and password
translations. However, in the default config file these options
are misspelled. Fix them to match the ones used in the components.