### PR TITLE
Document the existence of PartialBlur

### DIFF
--- a/theme.conf
+++ b/theme.conf
@@ -32,6 +32,8 @@ Font="Noto Sans"
 FontSize=
 ## Only set a fixed value if fonts are way too small for your resolution. Preferrably kept empty.
 
+PartialBlur="false"
+## When set to true makes the panel's opacity to be 0.3
 
 
 ## [Locale Settings]


### PR DESCRIPTION
Write the default value and functionality of `PartialBlur` in `theme.conf`.